### PR TITLE
Volume two-way interaction

### DIFF
--- a/tests/ExplicitCell/__init__.py
+++ b/tests/ExplicitCell/__init__.py
@@ -1,0 +1,20 @@
+
+
+def register_types(core):
+    core.register('set_float', {
+        '_inherit': 'float',
+        '_apply': 'set'})
+
+    core.register(
+        'positions',
+        'list[tuple[float,float,float]]')
+
+    # TODO: provide utility to set the '_apply' method to an existing schema
+    core.register(
+        'domains', {
+            '_type': 'map',
+            '_value': {
+                '_type': 'tuple',
+                '_apply': 'set',
+                '_0': 'positions',
+                '_1': 'positions'}})

--- a/tests/ExplicitCell/__init__.py
+++ b/tests/ExplicitCell/__init__.py
@@ -17,4 +17,7 @@ def register_types(core):
                 '_type': 'tuple',
                 '_apply': 'set',
                 '_0': 'positions',
-                '_1': 'positions'}})
+                '_1': 'positions'
+            }
+        }
+    )

--- a/tests/ExplicitCell/adapters/volume_from_particles.py
+++ b/tests/ExplicitCell/adapters/volume_from_particles.py
@@ -1,0 +1,31 @@
+from process_bigraph import Step, Composite, ProcessTypes, deep_merge
+
+
+class VolumeFromParticles(Step):
+    config_schema = {
+        'optimal_density': 'float'}
+
+
+    def __init__(self, config, core=None):
+        super().__init__(config, core)
+
+
+    def inputs(self):
+        return {
+            'domains': 'domains'
+        }
+
+
+    def outputs(self):
+        return {
+            'volumes': 'map[set_float]'}
+
+
+    def update(self, inputs):
+        volumes = {}
+        for domain_key, particles in inputs['domains'].items():
+            fluid_count = len(particles[1])
+            volumes[domain_key] = fluid_count * self.config['optimal_density']
+
+        return {
+            'volumes': volumes}

--- a/tests/ExplicitCell/adapters/volume_from_particles.py
+++ b/tests/ExplicitCell/adapters/volume_from_particles.py
@@ -5,21 +5,17 @@ class VolumeFromParticles(Step):
     config_schema = {
         'optimal_density': 'float'}
 
-
     def __init__(self, config, core=None):
         super().__init__(config, core)
-
 
     def inputs(self):
         return {
             'domains': 'domains'
         }
 
-
     def outputs(self):
         return {
             'volumes': 'map[set_float]'}
-
 
     def update(self, inputs):
         volumes = {}

--- a/tests/ExplicitCell/cc3d_simservice/CC3DProcess.py
+++ b/tests/ExplicitCell/cc3d_simservice/CC3DProcess.py
@@ -15,7 +15,6 @@ from simservice import service_function
 from process_bigraph import deep_merge
 
 cell_type_name = 'cell'
-cell_volume_target = 100
 cell_volume_lambda = 10
 
 
@@ -41,12 +40,19 @@ def specs(dim: Tuple[int, int]):
 
 class InterfaceSteppable(SteppableBasePy):
 
+    def __init__(self, *args, **kwargs):
+
+        super().__init__(*args, **kwargs)
+
+        self.init_cell_volume_target = 0
+
     def start(self):
         """Make proxy methods out of methods on this class"""
         service_function(self.add_cell)
         service_function(self.cell_mask)
         service_function(self.cell_ids)
         service_function(self.set_target_volumes)
+        service_function(self.set_initial_target_volume)
 
     @property
     def type(self):
@@ -57,7 +63,7 @@ class InterfaceSteppable(SteppableBasePy):
         """Adds a cell to the simulation"""
         new_cell = self.new_cell(self.type)
         new_cell.lambdaVolume = cell_volume_lambda
-        new_cell.targetVolume = cell_volume_target
+        new_cell.targetVolume = self.init_cell_volume_target
         for x, y in loc:
             self.cell_field[x, y, 0] = new_cell
         return new_cell.id
@@ -74,12 +80,15 @@ class InterfaceSteppable(SteppableBasePy):
         return [cell.id for cell in self.cell_list]
 
     def set_target_volumes(self, volumes):
-        for cell_id, cell_target_volume_ratio in volumes.items():
+        for cell_id, cell_volume_target in volumes.items():
             cell = self.fetch_cell_by_id(int(cell_id))
             if cell is None:
                 warnings.warn(f'Unknown cell id: {cell_id}')
             else:
-                cell.targetVolume = cell_volume_target * cell_target_volume_ratio
+                cell.targetVolume = cell_volume_target
+
+    def set_initial_target_volume(self, _cell_volume_target: float):
+        self.init_cell_volume_target = _cell_volume_target
 
 
 class CC3DProcess(SimServiceProcess):
@@ -88,6 +97,7 @@ class CC3DProcess(SimServiceProcess):
         merge_dct={
             'dim': 'tuple[integer,integer]',
             'initial_mask': 'any',
+            'init_cell_volume_target': 'float'
         })
 
     access_methods = {
@@ -105,6 +115,7 @@ class CC3DProcess(SimServiceProcess):
         # Extract implementation-specific inputs
         self._specs = {'dim': config['dim']}
         self._initial_mask = config['initial_mask']
+        self._init_cell_volume_target = config['init_cell_volume_target']
         super().__init__(config, core)
 
     def inputs(self):
@@ -130,19 +141,22 @@ class CC3DProcess(SimServiceProcess):
         self.service.register_steppable(InterfaceSteppable)
 
     def on_start(self, config=None):
+        # Handle service functions not being immediately available after startup
+        while True:
+            try:
+                self.service.set_initial_target_volume(self._init_cell_volume_target)
+                break
+            except AttributeError:
+                pass
+
         cell_ids = [cid for cid in np.unique(self._initial_mask) if cid != 0]
         initial_masks = []
         for cid in cell_ids:
             xcoords, ycoords = np.where(self._initial_mask == cid)
             initial_masks.append([(int(xcoords[i]), int(ycoords[i])) for i in range(xcoords.shape[0])])
         # Handle service functions not being immediately available after startup
-        while True:
-            try:
-                for im in initial_masks:
-                    self.service.add_cell(im)
-                break
-            except AttributeError:
-                pass
+        for im in initial_masks:
+            self.service.add_cell(im)
 
     def initial_state(self):
         return {
@@ -158,6 +172,7 @@ def run_cc3d_alone():
     dim = (30, 30)
     initial_mask = np.zeros(dim, dtype=int)
     initial_mask[10:15, 10:15] = 1
+    init_cell_volume_target = 25.0
 
     composite = {
         'cc3d': {
@@ -166,6 +181,7 @@ def run_cc3d_alone():
             'config': {
                 'dim': dim,
                 'initial_mask': initial_mask,
+                'init_cell_volume_target': init_cell_volume_target,
                 'process_config': {
                     'disable_ports': {
                         'inputs': [],

--- a/tests/ExplicitCell/cc3d_simservice/CC3DProcess.py
+++ b/tests/ExplicitCell/cc3d_simservice/CC3DProcess.py
@@ -73,9 +73,9 @@ class InterfaceSteppable(SteppableBasePy):
     def cell_ids(self) -> List[int]:
         return [cell.id for cell in self.cell_list]
 
-    def set_target_volumes(self, info: List[Tuple[int, float]]):
-        for cell_id, cell_target_volume_ratio in info:
-            cell = self.fetch_cell_by_id(cell_id)
+    def set_target_volumes(self, volumes):
+        for cell_id, cell_target_volume_ratio in volumes.items():
+            cell = self.fetch_cell_by_id(int(cell_id))
             if cell is None:
                 warnings.warn(f'Unknown cell id: {cell_id}')
             else:
@@ -87,7 +87,7 @@ class CC3DProcess(SimServiceProcess):
         dct=copy.deepcopy(SimServiceProcess.config_schema),
         merge_dct={
             'dim': 'tuple[integer,integer]',
-            'initial_mask': 'Any',
+            'initial_mask': 'any',
         })
 
     access_methods = {
@@ -109,11 +109,7 @@ class CC3DProcess(SimServiceProcess):
 
     def inputs(self):
         return {
-            'target_volumes': {
-                '_type': 'list',
-                '_apply': 'set'
-            }
-        }
+            'target_volumes': 'map[float]'}
 
     def outputs(self):
         return {

--- a/tests/ExplicitCell/explicit_cell.py
+++ b/tests/ExplicitCell/explicit_cell.py
@@ -24,6 +24,8 @@ from process_bigraph import Composite, ProcessTypes
 import numpy as np
 
 # these imports are done to import to registry
+from cc3d_simservice.CC3DProcess import SERVICE_NAME as cc3d_service_name
+from tf_simservice.TissueForgeProcess import SERVICE_NAME as tf_service_name
 from tests.ExplicitCell import register_types
 
 
@@ -271,7 +273,7 @@ def test_one_cell_two_directions(core):
                 'volumes': ['target_volumes_store'],
             }
         },
-        'domains_store': {'1': []}  # TODO (Ryan) -- this seems to want an existing value
+        # 'domains_store': {'1': []}  # TODO (Ryan) -- this seems to want an existing value
     }
 
     # combine all the specs
@@ -291,7 +293,6 @@ def test_one_cell_two_directions(core):
     # run it
     sim.run(5)
     results = sim.gather_results()
-
 
     print(results)
 

--- a/tests/ExplicitCell/explicit_cell.py
+++ b/tests/ExplicitCell/explicit_cell.py
@@ -24,16 +24,14 @@ from process_bigraph import Composite, ProcessTypes
 import numpy as np
 
 # these imports are done to import to registry
-from cc3d_simservice.CC3DProcess import SERVICE_NAME as cc3d_service_name
-from tf_simservice.TissueForgeProcess import SERVICE_NAME as tf_service_name
-from vivarium_simservice.emitter import get_emitter_schema
 from tests.ExplicitCell import register_types
-
-cell_type_name = 'cell'
-
 
 
 def test_one_cell_one_direction(core):
+    """
+    Run a cell model that connects CC3D and TissueForge, with interactions going in one direction, from CC3D to TissueForge.
+    """
+
     # Create the specs for a CC3D simulation
     dim = (30, 30, 30)
     cells = (6, 6, 6)
@@ -69,7 +67,6 @@ def test_one_cell_one_direction(core):
                         'outputs': []
                     }
                 },
-                # 'simservice_config': {}
             },
             'inputs': {
                 'target_volumes': ['target_volumes_store']
@@ -153,13 +150,13 @@ def test_one_cell_one_direction(core):
     # run it
     sim.run(5)
     results = sim.gather_results()
-
-    import ipdb; ipdb.set_trace()
-
     print(results)
 
     
 def test_one_cell_two_directions(core):
+    """
+    Run a cell model that connects CC3D and TissueForge, with interactions going in both directions.
+    """
     # Create the specs for a CC3D simulation
     dim = (30, 30, 30)
     cells = (6, 6, 6)
@@ -188,7 +185,6 @@ def test_one_cell_two_directions(core):
                         'outputs': []
                     }
                 },
-                # 'simservice_config': {}
             },
             'inputs': {
                 'target_volumes': ['target_volumes_store']
@@ -229,22 +225,27 @@ def test_one_cell_two_directions(core):
             },
             'outputs': {
                 'domains': ['domains_store']
-                # TODO map output to target_volumes
             }
         } for cell_id in initial_cell_ids
     }
 
+    # make a volume adapter that connects the fluid particles to the volume
     volume_config = {
         'volume_adapter': {
             '_type': 'step',
             'address': 'local:!tests.ExplicitCell.adapters.volume_from_particles.VolumeFromParticles',
             'config': {
                 # TODO: calculate this from the initial fluid particles
-                'optimal_density': 0.25},
+                'optimal_density': 0.25
+            },
             'inputs': {
-                'domains': ['domains_store']},
+                'domains': ['domains_store']
+            },
             'outputs': {
-                'volumes': ['target_volumes_store']}}}
+                'volumes': ['target_volumes_store']
+            }
+        }
+    }
 
     # configure the ram emitter
     ram_emitter_config = {
@@ -291,7 +292,6 @@ def test_one_cell_two_directions(core):
     sim.run(5)
     results = sim.gather_results()
 
-    import ipdb; ipdb.set_trace()
 
     print(results)
 

--- a/tests/ExplicitCell/explicit_cell.py
+++ b/tests/ExplicitCell/explicit_cell.py
@@ -27,15 +27,13 @@ import numpy as np
 from cc3d_simservice.CC3DProcess import SERVICE_NAME as cc3d_service_name
 from tf_simservice.TissueForgeProcess import SERVICE_NAME as tf_service_name
 from vivarium_simservice.emitter import get_emitter_schema
-
+from tests.ExplicitCell import register_types
 
 cell_type_name = 'cell'
 
 
 
-if __name__ == '__main__':
-    core = ProcessTypes()
-
+def test_one_cell_one_direction(core):
     # Create the specs for a CC3D simulation
     dim = (30, 30, 30)
     cells = (6, 6, 6)
@@ -146,4 +144,149 @@ if __name__ == '__main__':
     # run it
     sim.run(5)
     results = sim.gather_results()
+
+    import ipdb; ipdb.set_trace()
+
     print(results)
+
+    
+def test_one_cell_two_directions(core):
+    # Create the specs for a CC3D simulation
+    dim = (30, 30, 30)
+    cells = (6, 6, 6)
+
+    # make an initial mask array
+    initial_mask_array = np.zeros(shape=(dim[0], dim[1]), dtype=int)
+    initial_mask_array[10:20, 10:20] = 1
+
+    # list of initial cell ids
+    initial_cell_ids = [1]  # make this work for multiple cells
+
+    # configure compucell3D
+    compucell_config_dict = {
+        'cc3d': {
+            '_type': 'process',
+            'address': 'local:!cc3d_simservice.CC3DProcess.CC3DProcess',
+            'config': {
+                'dim': (dim[0], dim[1]),
+                'initial_mask': initial_mask_array,
+                'process_config': {
+                    'disable_ports': {
+                        'inputs': [],
+                        'outputs': []
+                    }
+                },
+                # 'simservice_config': {}
+            },
+            'inputs': {
+                'target_volumes': ['target_volumes_store']
+            },
+            'outputs': {
+                'cell_ids': ['cell_ids_store'],
+                'mask': ['mask_store']
+            }
+        },
+    }
+
+    # configure tissue forge
+    tissue_forge_config_dict = {
+        f'tissue-forge-{cell_id}': {
+            '_type': 'process',
+            'address': 'local:!tf_simservice.TissueForgeProcess.TissueForgeProcess',
+            'config': {
+                'cell_id': cell_id,
+                'initial_mask': initial_mask_array,
+                'dim': dim,
+                'cells': cells,
+                'per_dim': 5,
+                'num_steps': 1000,
+                'process_config': {
+                    'disable_ports': {
+                        'inputs': [],
+                        'outputs': []
+                    }
+                },
+                'simservice_config': {
+                    'dim': dim,
+                    'cells': cells,
+                }
+            },
+            'inputs': {
+                'mask': ['mask_store']
+            },
+            'outputs': {
+                'domains': ['domains_store']
+                # TODO map output to target_volumes
+            }
+        } for cell_id in initial_cell_ids
+    }
+
+    volume_config = {
+        'volume_adapter': {
+            '_type': 'step',
+            'address': 'local:!tests.ExplicitCell.adapters.volume_from_particles.VolumeFromParticles',
+            'config': {
+                # TODO: calculate this from the initial fluid particles
+                'optimal_density': 0.25},
+            'inputs': {
+                'domains': ['domains_store']},
+            'outputs': {
+                'volumes': ['target_volumes_store']}}}
+
+    # configure the ram emitter
+    ram_emitter_config = {
+        'ram-emitter': {
+            '_type': 'step',
+            'address': 'local:ram-emitter',
+            'config': {
+                'emit': {
+                    'mask': {
+                        '_type': 'array',
+                        '_shape': (dim[0], dim[1]),
+                        '_data': 'integer',
+                    },
+                    'domains': {
+                        '_type': 'domains',
+                    },
+                    'volumes': 'map[float]',
+                }
+            },
+            'inputs': {
+                'mask': ['mask_store'],
+                'domains': ['domains_store'],
+                'volumes': ['target_volumes_store'],
+            }
+        },
+    }
+
+    # combine all the specs
+    composite = {
+        **tissue_forge_config_dict,
+        **compucell_config_dict,
+        **volume_config,
+        **ram_emitter_config
+    }
+
+    # initialize the composite
+    sim = Composite(
+        {'state': composite},
+        core=core
+    )
+
+    # run it
+    sim.run(5)
+    results = sim.gather_results()
+
+    import ipdb; ipdb.set_trace()
+
+    print(results)
+
+    
+
+
+if __name__ == '__main__':
+    core = ProcessTypes()
+    register_types(core)
+
+    # test_one_cell_one_direction(core)
+    test_one_cell_two_directions(core)

--- a/tests/ExplicitCell/explicit_cell.py
+++ b/tests/ExplicitCell/explicit_cell.py
@@ -42,6 +42,15 @@ def test_one_cell_one_direction(core):
     initial_mask_array = np.zeros(shape=(dim[0], dim[1]), dtype=int)
     initial_mask_array[10:20, 10:20] = 1
 
+    # initial cell target volume
+    init_cell_volume_target = 100.0
+
+    # number of fluid particles is per_dim ** 2 * no. cell sites
+    # per_dim = 5
+    # no. cell sites = 100
+    # result was 400
+    # (5 * 10 - 2) ** 2
+
     # list of initial cell ids
     initial_cell_ids = [1]  # make this work for multiple cells
 
@@ -53,6 +62,7 @@ def test_one_cell_one_direction(core):
             'config': {
                 'dim': (dim[0], dim[1]),
                 'initial_mask': initial_mask_array,
+                'init_cell_volume_target': init_cell_volume_target,
                 'process_config': {
                     'disable_ports': {
                         'inputs': [],
@@ -79,10 +89,7 @@ def test_one_cell_one_direction(core):
             'config': {
                 'cell_id': cell_id,
                 'initial_mask': initial_mask_array,
-                'dim': dim,
-                'cells': cells,
-                'per_dim': 5,
-                'num_steps': 1000,
+                'growth_rate': 0,
                 'process_config': {
                     'disable_ports': {
                         'inputs': [],
@@ -92,6 +99,8 @@ def test_one_cell_one_direction(core):
                 'simservice_config': {
                     'dim': dim,
                     'cells': cells,
+                    'per_dim': 5,
+                    'num_steps': 1000,
                 }
             },
             'inputs': {

--- a/tests/ExplicitCell/explicit_cell.py
+++ b/tests/ExplicitCell/explicit_cell.py
@@ -168,6 +168,8 @@ def test_one_cell_two_directions(core):
     initial_mask_array = np.zeros(shape=(dim[0], dim[1]), dtype=int)
     initial_mask_array[10:20, 10:20] = 1
 
+    init_cell_volume_target = 100.0
+
     # list of initial cell ids
     initial_cell_ids = [1]  # make this work for multiple cells
 
@@ -179,6 +181,7 @@ def test_one_cell_two_directions(core):
             'config': {
                 'dim': (dim[0], dim[1]),
                 'initial_mask': initial_mask_array,
+                'init_cell_volume_target': init_cell_volume_target,
                 'process_config': {
                     'disable_ports': {
                         'inputs': [],
@@ -209,6 +212,7 @@ def test_one_cell_two_directions(core):
                 'cells': cells,
                 'per_dim': 5,
                 'num_steps': 1000,
+                'growth_rate': 0,   # number of particles added every simulation step
                 'process_config': {
                     'disable_ports': {
                         'inputs': [],
@@ -266,6 +270,7 @@ def test_one_cell_two_directions(core):
                 'volumes': ['target_volumes_store'],
             }
         },
+        'domains_store': {'1': []}  # TODO (Ryan) -- this seems to want an existing value
     }
 
     # combine all the specs

--- a/tests/ExplicitCell/tf_simservice/TissueForgeProcess.py
+++ b/tests/ExplicitCell/tf_simservice/TissueForgeProcess.py
@@ -29,13 +29,15 @@ class TissueForgeProcess(SimServiceProcess):
             'num_steps': 'integer',
             'cell_id': 'integer',
             'initial_mask': 'array[integer]',
+            'growth_rate': 'int'
         })
     config_schema.update()
 
     # access methods for the ports
     access_methods = {
         'inputs': {
-            'mask': 'set_next_mask'
+            'mask': 'set_next_mask',
+            'growth_rates': 'set_growth_rates'
         },
         'outputs': {
             'domains': 'get_domains'
@@ -45,7 +47,7 @@ class TissueForgeProcess(SimServiceProcess):
 
     def on_start(self, config=None):
         # TODO -- get the cell_id to match the mask
-        self.service.add_domain(self.config['cell_id'], self.config['initial_mask'])
+        self.service.add_domain(self.config['cell_id'], self.config['initial_mask'], self.config['growth_rate'])
 
     def inputs(self):
         return {
@@ -54,6 +56,12 @@ class TissueForgeProcess(SimServiceProcess):
                 '_shape': (self.config['dim'][0], self.config['dim'][1]),
                 '_data': 'integer',
                 '_apply': 'set',
+            },
+            'growth_rates': {
+                '_type': 'map',
+                '_value': {
+                    '_type': 'int'
+                }
             }
         }
 

--- a/tests/ExplicitCell/tf_simservice/TissueForgeProcess.py
+++ b/tests/ExplicitCell/tf_simservice/TissueForgeProcess.py
@@ -29,7 +29,7 @@ class TissueForgeProcess(SimServiceProcess):
             'num_steps': 'integer',
             'cell_id': 'integer',
             'initial_mask': 'array[integer]',
-            'growth_rate': 'int'
+            'growth_rate': 'integer'
         })
     config_schema.update()
 

--- a/tests/ExplicitCell/tf_simservice/TissueForgeProcess.py
+++ b/tests/ExplicitCell/tf_simservice/TissueForgeProcess.py
@@ -47,7 +47,11 @@ class TissueForgeProcess(SimServiceProcess):
 
     def on_start(self, config=None):
         # TODO -- get the cell_id to match the mask
-        self.service.add_domain(self.config['cell_id'], self.config['initial_mask'], self.config['growth_rate'])
+        self.service.add_domain(
+            self.config['cell_id'],
+            self.config['initial_mask'],
+            self.config['growth_rate']
+        )
 
     def inputs(self):
         return {
@@ -68,9 +72,6 @@ class TissueForgeProcess(SimServiceProcess):
     def outputs(self):
         return {
             'domains': 'domains'
-            # 'domains': {
-            #     '_type': 'any',   # TODO -- make this a real type
-            # }
         }
 
 

--- a/tests/ExplicitCell/tf_simservice/TissueForgeProcess.py
+++ b/tests/ExplicitCell/tf_simservice/TissueForgeProcess.py
@@ -59,9 +59,10 @@ class TissueForgeProcess(SimServiceProcess):
 
     def outputs(self):
         return {
-            'domains': {
-                '_type': 'any',   # TODO -- make this a real type
-            }
+            'domains': 'domains'
+            # 'domains': {
+            #     '_type': 'any',   # TODO -- make this a real type
+            # }
         }
 
 


### PR DESCRIPTION
TissueForge puts out a domains output, it is converted to target volume by the `volume_from_particles` translator, and CC3D reads it in.
@tjsego -- this is working! Ryan's recent update to bigraph-schema had the fix we needed, and just needed to pull the most recent version.